### PR TITLE
Improve pipe and compose test + explicit execution order

### DIFF
--- a/packages/compose/src/index.test.ts
+++ b/packages/compose/src/index.test.ts
@@ -2,10 +2,10 @@ import compose from './index'
 
 describe('@common-utilities/', () => {
   describe('compose', () => {
-    test('it composes', () => {
-      const add1 = (val: number): number => val + 1
-      const add2 = (val: number): number => val + 2
-      const result = compose(add1, add2)
+    test('it composes from right to left', () => {
+      const add = (val: number): number => val + 1
+      const multiply = (val: number): number => val * 2
+      const result = compose(add, multiply)
       expect(result(2)).toEqual(5)
     })
   })

--- a/packages/compose/src/index.ts
+++ b/packages/compose/src/index.ts
@@ -2,7 +2,7 @@
  * compose 🚂
  * ----
  * a common function that takes the output from one function
- * and automatically patches it to the input of the next function
+ * and automatically patches it to the input of the next function from right to left
  * until it spits out the final value
  * ----
  * @param {fns} an array of functions

--- a/packages/pipe/src/index.test.ts
+++ b/packages/pipe/src/index.test.ts
@@ -2,10 +2,10 @@ import pipe from './index'
 
 describe('@common-utilities/', () => {
   describe('pipe', () => {
-    test('it pipes', () => {
-      const add1 = (val: number): number => val + 1
-      const add2 = (val: number): number => val + 2
-      const result = pipe(add1, add2)
+    test('it pipes from left to right', () => {
+      const multiply = (val: number): number => val * 2
+      const add = (val: number): number => val + 1
+      const result = pipe(multiply, add)
       expect(result(2)).toEqual(5)
     })
   })

--- a/packages/pipe/src/index.ts
+++ b/packages/pipe/src/index.ts
@@ -2,7 +2,7 @@
  * pipe ⛓
  * ----
  * a common function that take the output from one function
- * and automatically patches it to the input of the next function
+ * and automatically patches it to the input of the next function from left to right
  * until it spits out the final value in the opposite order of Compose.
  * ----
  * @param {fns} an array of functions


### PR DESCRIPTION
## Fixes

Pipe and compose tests weren't robust enough. We could have changed `compose` execution orders from `left to right` to `right to left` but tests would still pass. So I improved them and made the execution order explicit in the doc and test.

Same goes for `pipe`' which is also improved!

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
